### PR TITLE
[FEAT] 계정 탈퇴 및 버그 수정

### DIFF
--- a/backend/src/main/java/com/prograngers/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/CommentController.java
@@ -33,7 +33,7 @@ public class CommentController {
     private static final String PAGE_NUMBER_DEFAULT = "1";
 
     @Login
-    @GetMapping("/mypage/comments")
+    @GetMapping("/comments")
     public ShowMyCommentsResponse showMyComments(@LoggedInMember Long memberId, @RequestParam(defaultValue = PAGE_NUMBER_DEFAULT) Integer pageNumber) {
         return commentService.showMyComments(memberId, pageNumber);
     }

--- a/backend/src/main/java/com/prograngers/backend/controller/DashBoardController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/DashBoardController.java
@@ -20,7 +20,7 @@ public class DashBoardController {
     private final DashBoardService dashBoardService;
 
     @Login
-    @GetMapping("/mypage/dashboard")
+    @GetMapping("/dashboard")
     public ShowDashBoardResponse show(@LoggedInMember Long memberId,
                                       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth date){
         return dashBoardService.getDashboard(memberId, date);

--- a/backend/src/main/java/com/prograngers/backend/controller/FollowController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/FollowController.java
@@ -32,7 +32,7 @@ public class FollowController {
     }
 
     @Login
-    @GetMapping("mypage/follows")
+    @GetMapping("/follows")
     public ResponseEntity<ShowFollowListResponse> followList(@LoggedInMember Long memberId){
         return ResponseEntity.ok().body(followService.getFollowList(memberId));
     }

--- a/backend/src/main/java/com/prograngers/backend/controller/LikesController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/LikesController.java
@@ -2,14 +2,18 @@ package com.prograngers.backend.controller;
 
 import com.prograngers.backend.controller.auth.LoggedInMember;
 import com.prograngers.backend.controller.auth.Login;
+import com.prograngers.backend.dto.solution.response.ShowMyLikeSolutionsResponse;
 import com.prograngers.backend.service.LikesService;
+import com.prograngers.backend.service.SolutionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
@@ -21,6 +25,9 @@ import java.net.URI;
 public class LikesController {
 
     private final LikesService likesService;
+    private final SolutionService solutionService;
+
+    private static final String DEFAULT_PAGE = "1";
 
     @Login
     @PostMapping("/solutions/{solutionId}/likes")
@@ -33,5 +40,11 @@ public class LikesController {
     public ResponseEntity<Void> cancel(@LoggedInMember Long memberId, @PathVariable Long solutionId){
         likesService.cancelLike(memberId,solutionId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Login
+    @GetMapping("/likes")
+    public ShowMyLikeSolutionsResponse showMyLikes(@RequestParam(defaultValue = DEFAULT_PAGE) int page, @LoggedInMember Long memberId) {
+        return solutionService.getMyLikes(memberId, page);
     }
 }

--- a/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.prograngers.backend.dto.member.response.ShowMemberAccountInfoResponse
 import com.prograngers.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,5 +40,12 @@ public class MemberController {
     @GetMapping("/members/{nickname}")
     public ShowMemberProfileResponse showProfile(@PathVariable String nickname, @RequestParam(defaultValue = "9223372036854775807") Long page){
         return memberService.getMemberProfile(nickname,page);
+    }
+
+    @Login
+    @DeleteMapping("/members")
+    public ResponseEntity<Void> delete(@LoggedInMember Long memberId) {
+        memberService.delete(memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
@@ -2,9 +2,10 @@ package com.prograngers.backend.controller;
 
 import com.prograngers.backend.controller.auth.LoggedInMember;
 import com.prograngers.backend.controller.auth.Login;
+import com.prograngers.backend.dto.member.response.ShowMemberAccountResponse;
 import com.prograngers.backend.dto.member.response.ShowMemberProfileResponse;
 import com.prograngers.backend.dto.member.request.UpdateMemberAccountInfoRequest;
-import com.prograngers.backend.dto.member.response.ShowMemberAccountInfoResponse;
+import com.prograngers.backend.dto.member.response.ShowBasicMemberAccountResponse;
 import com.prograngers.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class MemberController {
 
     @Login
     @GetMapping("/members")
-    public ShowMemberAccountInfoResponse showAccount(@LoggedInMember Long memberId) {
+    public ShowMemberAccountResponse showAccount(@LoggedInMember Long memberId) {
         return memberService.getMemberAccount(memberId);
     }
 

--- a/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
@@ -30,7 +30,7 @@ public class MemberController {
     }
 
     @Login
-    @PatchMapping("members")
+    @PatchMapping("/members")
     public ResponseEntity<Void> updateMemberAccountInfo(@LoggedInMember Long memberId,@RequestBody UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
         memberService.updateMemberAccountInfo(memberId, updateMemberAccountInfoRequest);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
@@ -26,14 +26,14 @@ public class MemberController {
 
     @Login
     @GetMapping("/members")
-    public ShowMemberAccountInfoResponse showAccountInfo(@LoggedInMember Long memberId) {
+    public ShowMemberAccountInfoResponse showAccount(@LoggedInMember Long memberId) {
         return memberService.getMemberAccount(memberId);
     }
 
     @Login
     @PatchMapping("/members")
-    public ResponseEntity<Void> updateMemberAccountInfo(@LoggedInMember Long memberId,@RequestBody UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
-        memberService.updateMemberAccountInfo(memberId, updateMemberAccountInfoRequest);
+    public ResponseEntity<Void> updateMemberAccount(@LoggedInMember Long memberId, @RequestBody UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
+        memberService.updateMemberAccount(memberId, updateMemberAccountInfoRequest);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/MemberController.java
@@ -7,7 +7,6 @@ import com.prograngers.backend.dto.member.request.UpdateMemberAccountInfoRequest
 import com.prograngers.backend.dto.member.response.ShowMemberAccountInfoResponse;
 import com.prograngers.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -27,13 +24,13 @@ public class MemberController {
     private final MemberService memberService;
 
     @Login
-    @GetMapping("/mypage/account-settings")
+    @GetMapping("/members")
     public ShowMemberAccountInfoResponse showAccountInfo(@LoggedInMember Long memberId) {
         return memberService.getMemberAccount(memberId);
     }
 
     @Login
-    @PatchMapping("/mypage/account-settings")
+    @PatchMapping("members")
     public ResponseEntity<Void> updateMemberAccountInfo(@LoggedInMember Long memberId,@RequestBody UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
         memberService.updateMemberAccountInfo(memberId, updateMemberAccountInfoRequest);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/prograngers/backend/controller/SolutionController.java
+++ b/backend/src/main/java/com/prograngers/backend/controller/SolutionController.java
@@ -5,7 +5,6 @@ import com.prograngers.backend.controller.auth.Login;
 import com.prograngers.backend.dto.solution.reqeust.ScarpSolutionRequest;
 import com.prograngers.backend.dto.solution.reqeust.UpdateSolutionRequest;
 import com.prograngers.backend.dto.solution.reqeust.WriteSolutionRequest;
-import com.prograngers.backend.dto.solution.response.ShowMyLikeSolutionsResponse;
 import com.prograngers.backend.dto.solution.response.ShowMySolutionDetailResponse;
 import com.prograngers.backend.dto.solution.response.ShowMySolutionListResponse;
 import com.prograngers.backend.dto.solution.response.ShowSolutionDetailResponse;
@@ -69,7 +68,7 @@ public class SolutionController {
         return solutionService.getSolutionDetail(solutionId, memberId);
     }
 
-    @GetMapping("/mypage/solutions/{solutionId}")
+    @GetMapping("/solutions/{solutionId}/mine")
     public ShowMySolutionDetailResponse showMyDetail(@PathVariable Long solutionId, @LoggedInMember Long memberId) {
         return solutionService.getMySolutionDetail(memberId, solutionId);
     }
@@ -85,7 +84,7 @@ public class SolutionController {
         return solutionService.getSolutionList(pageable, problemId, language, algorithm, dataStructure, sortBy);
     }
     @Login
-    @GetMapping("/mypage/solutions")
+    @GetMapping("/solutions")
     public ShowMySolutionListResponse showMyList(@RequestParam(required = false) String keyword,
                                                  @RequestParam(required = false) LanguageConstant language,
                                                  @RequestParam(required = false) AlgorithmConstant algorithm,
@@ -94,12 +93,6 @@ public class SolutionController {
                                                  @RequestParam(defaultValue = DEFAULT_PAGE) int page,
                                                  @LoggedInMember Long memberId) {
         return solutionService.getMyList(keyword, language, algorithm, dataStructure, level, page, memberId);
-    }
-
-    @Login
-    @GetMapping("/mypage/likes")
-    public ShowMyLikeSolutionsResponse showMyLikes(@RequestParam(defaultValue = DEFAULT_PAGE) int page, @LoggedInMember Long memberId) {
-        return solutionService.getMyLikes(memberId, page);
     }
 
 }

--- a/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowBasicMemberAccountResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowBasicMemberAccountResponse.java
@@ -4,31 +4,25 @@ import com.prograngers.backend.entity.member.Member;
 import com.prograngers.backend.entity.member.MemberType;
 import com.prograngers.backend.support.Encrypt;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 
-@Data
-@Builder
-public class ShowMemberAccountInfoResponse {
-
-    private MemberType type;
-
-    private String nickname;
-
-    private String email;
-
-    private String github;
-
-    private String introduction;
-
-    private LocalDateTime passwordModifiedAt;
+@Getter
+public class ShowBasicMemberAccountResponse extends ShowMemberAccountResponse{
 
     private String password;
+    private LocalDateTime passwordModifiedAt;
 
-    private String photo;
+    @Builder
+    public ShowBasicMemberAccountResponse(MemberType type, String nickname, String email, String github, String introduction, String photo, String password, LocalDateTime passwordModifiedAt) {
+        super(type, nickname, email, github, introduction, photo);
+        this.password = password;
+        this.passwordModifiedAt = passwordModifiedAt;
+    }
 
-    public static ShowMemberAccountInfoResponse from(Member member) {
-        return ShowMemberAccountInfoResponse.builder()
+    public static ShowBasicMemberAccountResponse from(Member member) {
+        return ShowBasicMemberAccountResponse.builder()
                 .type(member.getType())
                 .nickname(member.getNickname())
                 .email(member.getEmail())

--- a/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowMemberAccountResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowMemberAccountResponse.java
@@ -1,0 +1,15 @@
+package com.prograngers.backend.dto.member.response;
+
+import com.prograngers.backend.entity.member.MemberType;
+import lombok.Builder;
+
+@Builder
+public abstract class ShowMemberAccountResponse {
+
+    private MemberType type;
+    private String nickname;
+    private String email;
+    private String github;
+    private String introduction;
+    private String photo;
+}

--- a/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowMemberProfileResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowMemberProfileResponse.java
@@ -6,7 +6,6 @@ import com.prograngers.backend.entity.badge.BadgeConstant;
 import com.prograngers.backend.entity.member.Member;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.util.List;
 
 @Getter

--- a/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowSocialMemberAccountResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/member/response/ShowSocialMemberAccountResponse.java
@@ -1,0 +1,25 @@
+package com.prograngers.backend.dto.member.response;
+
+import com.prograngers.backend.entity.member.Member;
+import com.prograngers.backend.entity.member.MemberType;
+import com.prograngers.backend.support.Encrypt;
+import lombok.Builder;
+
+public class ShowSocialMemberAccountResponse extends ShowMemberAccountResponse {
+
+    @Builder
+    ShowSocialMemberAccountResponse(MemberType type, String nickname, String email, String github, String introduction, String photo) {
+        super(type, nickname, email, github, introduction, photo);
+    }
+
+    public static ShowSocialMemberAccountResponse from(Member member) {
+        return ShowSocialMemberAccountResponse.builder()
+                .type(member.getType())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .github(member.getGithub())
+                .introduction(member.getIntroduction())
+                .photo(member.getPhoto())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/prograngers/backend/dto/solution/response/SolutionForLikeResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/solution/response/SolutionForLikeResponse.java
@@ -32,15 +32,7 @@ public class SolutionForLikeResponse {
                 .algorithm(solution.getAlgorithmView())
                 .dataStructure(solution.getDataStructureView())
                 .build();
-
         return response;
     }
 
-    private void setAlgorithm(String algorithm) {
-        this.algorithm = algorithm;
-    }
-
-    private void setDataStructure(String dataStructure) {
-        this.dataStructure = dataStructure;
-    }
 }

--- a/backend/src/main/java/com/prograngers/backend/dto/solution/response/SolutionForListResponse.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/solution/response/SolutionForListResponse.java
@@ -1,6 +1,5 @@
 package com.prograngers.backend.dto.solution.response;
 
-import com.prograngers.backend.entity.problem.Problem;
 import com.prograngers.backend.entity.solution.Solution;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +16,7 @@ public class SolutionForListResponse {
     private String dataStructure;
     private String language;
     private int level;
+    private boolean isScrapped;
 
     public static SolutionForListResponse from(Solution solution) {
         SolutionForListResponse response = SolutionForListResponse.builder()
@@ -26,16 +26,9 @@ public class SolutionForListResponse {
                 .level(solution.getLevel())
                 .algorithm(solution.getAlgorithmView())
                 .dataStructure(solution.getDataStructureView())
+                .isScrapped(solution.isScrapped())
                 .build();
-
         return response;
     }
 
-    private void setAlgorithm(String algorithm) {
-        this.algorithm = algorithm;
-    }
-
-    private void setDataStructure(String dataStructure) {
-        this.dataStructure = dataStructure;
-    }
 }

--- a/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
@@ -54,6 +54,9 @@ public class Member {
     @Column(name = "password_modified_at")
     private LocalDateTime passwordModifiedAt;
 
+    @Column(name = "usable", nullable = false)
+    private boolean usable;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
@@ -127,6 +127,10 @@ public class Member {
         }
     }
 
+    public void delete() {
+        this.usable = false;
+    }
+
     public void update(Member member) {
         updateNickName(member.getNickname());
         updateGitHub(member.getGithub());

--- a/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
@@ -129,4 +129,11 @@ public class Solution {
         return null;
     }
 
+    public boolean isScrapped() {
+        if (scrapSolution == null) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
@@ -130,10 +130,7 @@ public class Solution {
     }
 
     public boolean isScrapped() {
-        if (scrapSolution == null) {
-            return false;
-        }
-        return true;
+        return scrapSolution != null;
     }
 
 }

--- a/backend/src/main/java/com/prograngers/backend/service/MemberService.java
+++ b/backend/src/main/java/com/prograngers/backend/service/MemberService.java
@@ -18,7 +18,6 @@ import com.prograngers.backend.repository.solution.SolutionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 
 @Service
@@ -72,6 +71,7 @@ public class MemberService {
         if(member.getPassword().equals(updateMemberAccountInfoRequest.getOldPassword()))
             throw new IncorrectPasswordException();
     }
+
     private void validNicknameBlank(String nickname) {
         if(nickname.isBlank()) throw new BlankNicknameException();
     }
@@ -93,5 +93,11 @@ public class MemberService {
 
     private Member findByNickname(String memberNickname) {
         return memberRepository.findByNickname(memberNickname).orElseThrow(MemberNotFoundException::new);
+    }
+
+    @Transactional
+    public void delete(Long memberId) {
+        Member member = findById(memberId);
+        member.delete();
     }
 }

--- a/backend/src/main/java/com/prograngers/backend/service/MemberService.java
+++ b/backend/src/main/java/com/prograngers/backend/service/MemberService.java
@@ -40,15 +40,16 @@ public class MemberService {
 
 
     @Transactional
-    public void updateMemberAccountInfo(Long memberId, UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
+    public void updateMemberAccount(Long memberId, UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {
         Member member = findById(memberId);
-        validMemberAccountInfo(updateMemberAccountInfoRequest, member);
+        validMemberAccount(updateMemberAccountInfoRequest, member);
         member.update(updateMemberAccountInfoRequest.toMember());
     }
 
-    private void validMemberAccountInfo(UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest, Member member) {
+    private void validMemberAccount(UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest, Member member) {
         String nickname = updateMemberAccountInfoRequest.getNickname();
-        if(nickname !=null){
+
+        if (nickname != null) {
             validNicknameBlank(nickname);
             validNicknameDuplication(nickname);
         }
@@ -56,7 +57,6 @@ public class MemberService {
         if (updateMemberAccountInfoRequest.getNewPassword() != null) {
             validExistOldPassword(updateMemberAccountInfoRequest);
             validCorrectPassword(updateMemberAccountInfoRequest, member);
-
         }
 
     }

--- a/backend/src/main/java/com/prograngers/backend/service/MemberService.java
+++ b/backend/src/main/java/com/prograngers/backend/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.prograngers.backend.service;
 
+import com.prograngers.backend.dto.member.response.ShowMemberAccountResponse;
 import com.prograngers.backend.dto.member.response.ShowMemberProfileResponse;
 import com.prograngers.backend.dto.member.request.UpdateMemberAccountInfoRequest;
-import com.prograngers.backend.dto.member.response.ShowMemberAccountInfoResponse;
+import com.prograngers.backend.dto.member.response.ShowBasicMemberAccountResponse;
+import com.prograngers.backend.dto.member.response.ShowSocialMemberAccountResponse;
 import com.prograngers.backend.entity.badge.Badge;
+import com.prograngers.backend.entity.member.MemberType;
 import com.prograngers.backend.entity.solution.Solution;
 import com.prograngers.backend.entity.member.Member;
 import com.prograngers.backend.exception.badrequest.BlankNicknameException;
@@ -30,14 +33,17 @@ public class MemberService {
     private final SolutionRepository solutionRepository;
     private final FollowRepository followRepository;
 
-    public ShowMemberAccountInfoResponse getMemberAccount(Long memberId){
-        return ShowMemberAccountInfoResponse.from(findById(memberId));
+    public ShowMemberAccountResponse getMemberAccount(Long memberId){
+        Member member = findById(memberId);
+        if(member.getType() == MemberType.BASIC) {
+            return ShowBasicMemberAccountResponse.from(member);
+        }
+        return ShowSocialMemberAccountResponse.from(member);
     }
 
     private Member findById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
     }
-
 
     @Transactional
     public void updateMemberAccount(Long memberId, UpdateMemberAccountInfoRequest updateMemberAccountInfoRequest) {


### PR DESCRIPTION
## 연결 Issue 
#187 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [x] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 테스트코드 작성
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
feature/187-member-quit


### ❔ 변경 사항
회원 탈퇴 기능을 구현했습니다. 회원은 탈퇴시 데이터가 삭제되지 않고 disable됩니다. 
따라서 이제 풀이, 댓글, 리뷰 조회시 탈퇴한 회원이 작성한 것인지 확인해야합니다. 

mypage와 관련된 모든 URI에서  /mypage가 삭제되었습니다. 관련 POSTMAN도 수정바랍니다.

계정정보 조회시 일반 회원 / 소셜 회원 의 반환 값이 달라 DTO를 둘로 나누고 공통적으로 추상 클래스를 두어 관리하도록 변경했습니다. 

내 풀이 목록에서 스크랩 여부를 알 수 있도록 스크랩 여부를 알 수 있는 필드를 반환 DTO에 추가했습니다. 

### Postman 수정 필수 

