### PR TITLE
[FEAT] 탈퇴한 사용자 닉네임 기능 추가

### DIFF
--- a/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
@@ -10,15 +10,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
 
 
 @Entity
@@ -27,6 +26,7 @@ import java.util.Objects;
 @EntityListeners(AuditingEntityListener.class)
 public class Member {
 
+    private static final String QUIT_NICKNAME = "탈퇴한 사용자";
     private static final List<String> PROHIBITED_NICKNAMES = List.of("탈퇴한 사용자");
 
     @Id
@@ -61,8 +61,12 @@ public class Member {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Member member = (Member) o;
         return Objects.equals(id, member.id);
     }
@@ -73,7 +77,9 @@ public class Member {
     }
 
     @Builder
-    public Member(Long id, Long socialId, MemberType type, String nickname, String email, String github, String introduction, String password, String photo, LocalDateTime passwordModifiedAt, boolean usable) {
+    public Member(Long id, Long socialId, MemberType type, String nickname, String email, String github,
+                  String introduction, String password, String photo, LocalDateTime passwordModifiedAt,
+                  boolean usable) {
         validProhibitionNickname(nickname);
         this.id = id;
         this.socialId = socialId;
@@ -132,8 +138,8 @@ public class Member {
         }
     }
 
-    private void updatePhoto(String photo){
-        if (photo!=null){
+    private void updatePhoto(String photo) {
+        if (photo != null) {
             this.photo = photo;
         }
     }
@@ -152,5 +158,12 @@ public class Member {
         updateIntroduction(member.getIntroduction());
         updatePassword(member.getPassword());
         updatePhoto(member.getPhoto());
+    }
+
+    public String getNickname() {
+        if (isUsable()) {
+            return nickname;
+        }
+        return QUIT_NICKNAME;
     }
 }

--- a/backend/src/test/java/com/prograngers/backend/entity/member/MemberTest.java
+++ b/backend/src/test/java/com/prograngers/backend/entity/member/MemberTest.java
@@ -1,0 +1,27 @@
+package com.prograngers.backend.entity.member;
+
+import static com.prograngers.backend.support.fixture.MemberFixture.장지담;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    private static final String QUIT_NICKNAME = "탈퇴한 사용자";
+
+    @DisplayName("탈퇴하지 않은 회원일 경우 닉네임을 정상 반환한다.")
+    @Test
+    void getNicknameTest() {
+        Member member = 장지담.기본_정보_생성();
+        assertThat(member.getNickname()).isEqualTo("jidam99");
+    }
+
+    @DisplayName("탈퇴한 회원일 경우 탈퇴한 사용자를 닉네임 대신 반환한다")
+    @Test
+    void getNicknameWhenQuitTest() {
+        Member quit = 장지담.탈퇴_회원_생성();
+        assertThat(quit.getNickname()).isEqualTo(QUIT_NICKNAME);
+    }
+
+}


### PR DESCRIPTION
## #210 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [ ] 버그 수정
* [ ] 테스트코드 작성
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
feat/210-quitMemberName -> develop

### ❔ 변경 사항
탈퇴한 사용자일 경우 getNickname에서 `탈퇴한 사용자`를 반환하도록 했습니다

### 🔍 테스트 결과
로직이 Member 엔티티에 있어서 MemberTest를 추가했습니다

### 📰 참고 Reference
 
### ⚒️ 기타 사항

