### PR TITLE
[FIX] 계정 수정, 대시보드 500 에러 수정

### DIFF
--- a/backend/src/main/java/com/prograngers/backend/dto/member/request/UpdateMemberAccountInfoRequest.java
+++ b/backend/src/main/java/com/prograngers/backend/dto/member/request/UpdateMemberAccountInfoRequest.java
@@ -20,6 +20,7 @@ public class UpdateMemberAccountInfoRequest {
 
     public Member toMember() {
         return Member.builder()
+                .usable(true)
                 .nickname(this.nickname)
                 .github(this.github)
                 .introduction(this.introduction)

--- a/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/member/Member.java
@@ -95,7 +95,7 @@ public class Member {
     }
 
     private void validProhibitionNickname(String nickname) {
-        if (PROHIBITED_NICKNAMES.contains(nickname)) {
+        if (nickname != null && PROHIBITED_NICKNAMES.contains(nickname)) {
             throw new ProhibitionNicknameException();
         }
     }

--- a/backend/src/main/java/com/prograngers/backend/repository/solution/SolutionCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/prograngers/backend/repository/solution/SolutionCustomRepositoryImpl.java
@@ -95,7 +95,10 @@ public class SolutionCustomRepositoryImpl implements SolutionCustomRepository {
         return jpaQueryFactory.selectFrom(solution)
                 .join(follow).on(solution.member.id.eq(follow.followingId))
                 .join(solution.problem).fetchJoin()
-                .where(follow.followerId.eq(memberId))
+                .where(
+                        follow.followerId.eq(memberId),
+                        solution.isPublic.isTrue()
+                )
                 .orderBy(solution.createdAt.desc())
                 .limit(limit)
                 .fetch();

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -99,15 +99,15 @@ CREATE TABLE IF NOT EXISTS `solution`
 
 CREATE TABLE IF NOT EXISTS `notification`
 (
-    `id`          BIGINT NOT NULL auto_increment,
-    `title`       VARCHAR(255) NOT NULL,
-    `type`        VARCHAR(255) NOT NULL,
-    `created_at`  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `id_read`     TINYINT(1) NOT NULL,
-    `member_id`   BIGINT NOT NULL,
-    `solution_id` BIGINT NOT NULL,
-    `comment_id`  BIGINT,
-    `review_id`   BIGINT,
+    `id`              BIGINT       NOT NULL auto_increment,
+    `writer_nickname` VARCHAR(255) NOT NULL,
+    `type`            VARCHAR(255) NOT NULL,
+    `created_at`      TIMESTAMP    NOT NULL,
+    `is_read`         TINYINT(1)   NOT NULL,
+    `receiver_id`     BIGINT       NOT NULL,
+    `solution_id`     BIGINT       NOT NULL,
+    `comment_id`      BIGINT,
+    `review_id`       BIGINT,
     PRIMARY KEY ( `id` )
 )
     engine = innodb


### PR DESCRIPTION
## 연결 Issue 
#265 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 테스트코드 작성
* [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
fix/256-member-dashboard -> develop

### ❔ 변경 사항

QA 시 발생했던 500에러를 수정했습니다. 

- 대시보드의 `팔로우의 최근풀이`에서 private 풀이가 뜨는 것 수정
- Member를 생성할 때 무조건 nickname을 validation 하던 것을 null값을 체크하고 validation 하도록 변경
- init.sql의 notification 쿼리문을 수정