### PR TITLE
[BUG] 타인 프로필 보기에서 비공개 풀이 보이는 버그 수정

### DIFF
--- a/backend/src/main/java/com/prograngers/backend/repository/solution/SolutionCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/prograngers/backend/repository/solution/SolutionCustomRepositoryImpl.java
@@ -62,7 +62,7 @@ public class SolutionCustomRepositoryImpl implements SolutionCustomRepository {
         return jpaQueryFactory
                 .select(solution)
                 .from(solution)
-                .where(solution.member.id.eq(memberId), solution.id.loe(page))
+                .where(solution.member.id.eq(memberId), solution.id.loe(page), solution.isPublic.eq(true))
                 .orderBy(solution.createdAt.desc())
                 .limit(3)
                 .fetch();


### PR DESCRIPTION
## #268

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 테스트코드 작성
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
bug/268-othersProfilePagePrivateSolution -> develop


### ❔ 변경 사항
querydsl Impl 파일을 수정해서 타인 프로필 보기 결과로 비공개 풀이는 보이지 않도록 했습니다.

### 🔍 테스트 결과
postman으로 확인했습니다.

