### PR TITLE
[Bug] 알고리즘 자료구조 api 형태 통일

### DIFF
--- a/backend/src/main/java/com/prograngers/backend/entity/solution/AlgorithmConstant.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/AlgorithmConstant.java
@@ -39,6 +39,4 @@ public enum AlgorithmConstant implements HashTag {
         }
         throw new AlgorithmNotFoundException();
     }
-
-
 }

--- a/backend/src/main/java/com/prograngers/backend/entity/solution/AlgorithmConstant.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/AlgorithmConstant.java
@@ -7,42 +7,38 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum AlgorithmConstant implements HashTag {
-    BUBBLE_SORT("버블 정렬"),
-    SELECTION_SORT("선택 정렬"),
-    INSERTION_SORT("삽입 정렬"),
-    HEAP_SORT("힙 정렬"),
-    MERGE_SORT("병합 정렬"),
-    QUICK_SORT("퀵 정렬"),
-    LINEAR_SEARCH("선형 정렬"),
-    BINARY_SEARCH("이진 탐색"),
-    BFS("BFS"),
-    DFS("DFS"),
-    MATH("수학"),
-    DYNAMIC_PROGRAMMING("동적 프로그래밍"),
-    GREEDY("그리디 알고리즘"),
-    BRUTE_FORCE("브루트포스 알고리즘"),
-    PREFIX_SUM("누적 합"),
-    COMBINATORICS("조합론"),
-    DIVIDE_AND_CONQUER("분할 정복"),
-    TWO_POINTER("투 포인터"),
-    RECURSION("재귀"),
-    SLIDING_WINDOW("슬라이딩 윈도우"),
-    BELLMAN_FORD("벨만-포드"),
-    DIJKSTRA("다익스트라");
-
-    private final String view;
+    BUBBLE_SORT,
+    SELECTION_SORT,
+    INSERTION_SORT,
+    HEAP_SORT,
+    MERGE_SORT,
+    QUICK_SORT,
+    LINEAR_SEARCH,
+    BINARY_SEARCH,
+    BFS,
+    DFS,
+    MATH,
+    DYNAMIC_PROGRAMMING,
+    GREEDY,
+    BRUTE_FORCE,
+    PREFIX_SUM,
+    COMBINATORICS,
+    DIVIDE_AND_CONQUER,
+    TWO_POINTER,
+    RECURSION,
+    SLIDING_WINDOW,
+    BELLMAN_FORD,
+    DIJKSTRA;
 
     @JsonCreator
     public static AlgorithmConstant from(String value) {
         for (AlgorithmConstant algorithm : AlgorithmConstant.values()) {
-            if (algorithm.getView().equals(value)) {
+            if (algorithm.name().equals(value)) {
                 return algorithm;
             }
         }
         throw new AlgorithmNotFoundException();
     }
 
-    public String getView() {
-        return view;
-    }
+
 }

--- a/backend/src/main/java/com/prograngers/backend/entity/solution/DataStructureConstant.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/DataStructureConstant.java
@@ -7,26 +7,20 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum DataStructureConstant implements HashTag {
-    LIST("리스트"),
-    ARRAY("배열"),
-    STACK("스택"),
-    QUEUE("큐"),
-    MAP("맵"),
-    HEAP("힙");
-
-    private final String view;
+    LIST,
+    ARRAY,
+    STACK,
+    QUEUE,
+    MAP,
+    HEAP;
 
     @JsonCreator
     public static DataStructureConstant from(String value) {
         for (DataStructureConstant dataStructure : DataStructureConstant.values()) {
-            if (dataStructure.getView().equals(value)) {
+            if (dataStructure.name().equals(value)) {
                 return dataStructure;
             }
         }
         throw new DataStructureNotFoundException();
-    }
-
-    public String getView() {
-        return view;
     }
 }

--- a/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
+++ b/backend/src/main/java/com/prograngers/backend/entity/solution/Solution.java
@@ -1,6 +1,5 @@
 package com.prograngers.backend.entity.solution;
 
-import com.prograngers.backend.dto.solution.reqeust.UpdateSolutionRequest;
 import com.prograngers.backend.entity.member.Member;
 import com.prograngers.backend.entity.problem.Problem;
 import com.prograngers.backend.support.converter.AlgorithmConverter;
@@ -130,14 +129,14 @@ public class Solution {
 
     public String getAlgorithmView() {
         if (algorithm != null) {
-            return algorithm.getView();
+            return algorithm.name();
         }
         return null;
     }
 
     public String getDataStructureView() {
         if (dataStructure != null) {
-            return dataStructure.getView();
+            return dataStructure.name();
         }
         return null;
     }


### PR DESCRIPTION
## #269 

### 💡 PR 타입(하나 이상의 PR 타입을 선택해주세요)
* [ ] 기능 추가
* [ ] 기능 삭제
* [x] 버그 수정
* [ ] 테스트코드 작성
* [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📲 반영 브랜치
bug/269-unifyAlgorithmDatastructure -> 1-develop


### ❔ 변경 사항
api에서 알고리즘, 자료구조를 주고받을 때 영문 대문자 (즉 enum의 name값)으로 주고받도록 수정했습니다.
클라이언트-서버간 통신 뿐만 아니라 서버에서도 algorithmconstant, datastructureconstant의 name값만 사용하게 됩니다. (view는 애초에 클라이언트에게 보여주기 위해 도입한 것이므로) 따라서 불필요해진 view 필드를 삭제했습니다. 
view 필드를 삭제함에 따라 json -> 객체 로 변환할 때 사용하는 algorithmconstant, datastructureconstant의 정적 팩터리 메서드 from (@JsonCreater가 붙은) 에서 name을 통해 String과 비교하도록 했습니다.  Solution의 get~View 메서드는 이제 name을 반환합니다. 
![image](https://github.com/rlfrkdms1/Prog-rangers/assets/96513365/e0c9ef55-0c3a-4bb1-b33c-c6cfd44d0bb1)
클라이언트는 이렇게 풀이 작성을 요청하게 됩니다. (MERGE_SORT, LIST)
![image](https://github.com/rlfrkdms1/Prog-rangers/assets/96513365/d9080812-957a-4e24-992c-958937dbaca7)
이렇게 응답을 얻습니다. 

### 🔍 테스트 결과
postman으로 테스트했습니다. 

### 참고 reference
[https://kimsup10.wordpress.com/2019/04/02/jsoncreator%EB%8A%94-%EC%99%9C-%EC%93%B0%EB%8A%94%EA%B1%B8%EA%B9%8C/](url) 
@jsoncreater 관련해서 참고한 내용입니다.


